### PR TITLE
add enum value to switch

### DIFF
--- a/src/routez/server.zig
+++ b/src/routez/server.zig
@@ -121,6 +121,7 @@ pub const Server = struct {
                 error.Unexpected,
                 error.ConnectionResetByPeer,
                 error.NetworkSubsystemFailed,
+                error.PermissionDenied,
                 => continue,
                 error.BlockedByFirewall => |e| return e,
                 error.FileDescriptorNotASocket,


### PR DESCRIPTION
I got a compiler error when I first cloned the repo using zig 0.7.1. Adding this enum addressed it, though I believe I tried 0.8.0 and did not need to handle PermissionDenied, so the stdlib might have changed again.