### PR TITLE
Use std.atomic.Atomic instead of std.atomic.Int

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -40,7 +40,7 @@ fn postHandler(req: Request, res: Response, args: *const struct {
     try res.print("Hello from post, post_num is {s}\n", .{args.post_num});
 }
 
-var counter = std.atomic.Int(usize).init(0);
+var counter = std.atomic.Atomic(usize).init(0);
 fn counterHandler(req: Request, res: Response) !void {
-    try res.print("Page loaded {d} times\n", .{counter.fetchAdd(1)});
+    try res.print("Page loaded {d} times\n", .{counter.fetchAdd(1, .SeqCst)});
 }


### PR DESCRIPTION
Since std.atomic.Int was replaced by std.atomic.Atomic at
"std.sync.atomic: extended atomic helper functions by kprotty · Pull Request #8866 · ziglang/zig"
https://github.com/ziglang/zig/pull/8866